### PR TITLE
stringdistmatrix is missing `p` when `ncores==1`

### DIFF
--- a/pkg/R/stringdist.R
+++ b/pkg/R/stringdist.R
@@ -210,7 +210,7 @@ stringdistmatrix <- function(a, b,
   a <- char2int(a)
   b <- lapply(char2int(b),list)
   if (ncores==1){
-    x <- sapply(b,do_dist,a,method,weight,maxDist, q)
+    x <- sapply(b,do_dist,a,method,weight,maxDist, q, p)
   } else {
     if ( is.null(cluster) ){
       cl <- makeCluster(ncores)


### PR DESCRIPTION
in stringdistmatrix
this line was missing the argument `p`:
  if (ncores==1){
     x <- sapply(b,do_dist,a,method,weight,maxDist, q, p)
   }
