### PR TITLE
Edited seq_distmatrix for case when b is not provided

### DIFF
--- a/pkg/R/seqdist.R
+++ b/pkg/R/seqdist.R
@@ -108,6 +108,8 @@ seq_distmatrix <- function(a, b
     return( lower_tri(a
         , method=method
         , weight=weight
+        , q=q
+        , p=p
         , useNames=useNames
         , nthread=nthread)
     )


### PR DESCRIPTION
In current implementation, p and q are not passed to lower_tri() when b is not present. This was causing default arguments to be passed whenever b was not provided.