### PR TITLE
change suggested func in 'did you mean to use' warning

### DIFF
--- a/pkg/R/stringdist.R
+++ b/pkg/R/stringdist.R
@@ -149,7 +149,7 @@ stringdist <- function(a, b
   if (maxDist < Inf)
     warning("Argument 'maxDist' is deprecated for function 'stringdist'. This argument will be removed in the future.")   
   if (is.list(a)|is.list(b))
-    warning(listwarning("stringdist","seqdist"))
+    warning(listwarning("stringdist","seq_dist"))
             
   stopifnot(
     all(is.finite(weight))
@@ -221,7 +221,7 @@ stringdistmatrix <- function(a, b
     message("Argument 'cluster' is deprecaterd as stringdust now uses multithreading by default. The argument is currently ignored and will be removed in the future")
   }
   if (is.list(a)|| (!missing(b) && is.list(b)) ){
-   warning(listwarning("stringdistmatrix","seqdistmatrix"))
+   warning(listwarning("stringdistmatrix","seq_distmatrix"))
   }
 
   # for backward compatability with stringdist <= 0.9.0


### PR DESCRIPTION
Updated the suggested function names passed as args to `listwarning()`. Here's an example:
```r
stringdist::stringdist(list(55, 56), c(67, 56))
```
Output is this:
```
[1] 2 0
Warning message:
In stringdist::stringdist(list(55, 56), c(67, 56)) : 
You are passing one or more arguments of type 'list' to
'stringdist'. These arguments will be converted with 'as.character'
which is likeley not to give what you want (did you mean to use 'seqdist'?).
This warning can be avoided by explicitly converting the argument(s).
```
`seqdist()` is not an exported function, but `seq_dist()` is. This PR changes the suggested function to be `seq_dist` (same with `stringdistmatrix()`, the suggested function name passed to `listwarning()` was edited to be `seq_distmatrix`).